### PR TITLE
Add testing note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,6 @@ You can cite the `nf-core` publication as follows:
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.
 >
 > _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).
+
+---
+> **Note**: This repository is used for testing and development purposes.


### PR DESCRIPTION
This pull request adds a simple 1-line note to the end of the README indicating that this repository is used for testing and development purposes.

## Changes Made:
- Added a note at the bottom of README.md: `> **Note**: This repository is used for testing and development purposes.`

This is a minimal change that provides clarity about the repository's purpose without affecting any functional aspects of the pipeline.