### PR TITLE
Add Seqera Platform compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-**nf-core/rnaseq** is a bioinformatics pipeline that can be used to analyse RNA sequencing data obtained from organisms with a reference genome and annotation. It takes a samplesheet with FASTQ files or pre-aligned BAM files as input, performs quality control (QC), trimming and (pseudo-)alignment, and produces a gene expression matrix and extensive QC report.
+**nf-core/rnaseq** is a bioinformatics pipeline that can be used to analyse RNA sequencing data obtained from organisms with a reference genome and annotation. This pipeline runs seamlessly on the Seqera Platform for scalable, cloud-native execution. It takes a samplesheet with FASTQ files or pre-aligned BAM files as input, performs quality control (QC), trimming and (pseudo-)alignment, and produces a gene expression matrix and extensive QC report.
 
 ![nf-core/rnaseq metro map](docs/images/nf-core-rnaseq_metro_map_grey_animated.svg)
 


### PR DESCRIPTION
## Summary
Added a brief mention that the nf-core/rnaseq pipeline runs seamlessly on the Seqera Platform for scalable, cloud-native execution.

## Changes Made
- Enhanced the Introduction section to highlight Seqera Platform compatibility
- Simple one-line addition that improves visibility of platform integration

## Benefits
- Informs users about cloud-native execution capabilities
- Highlights the seamless integration with Seqera Platform
- Maintains the original README structure and content

This is a minimal, non-breaking change that adds valuable information for users considering platform deployment options.