### PR TITLE
Switch default aligner from STAR to HISAT2

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     ribo_database_manifest     = "${projectDir}/workflows/rnaseq/assets/rrna-db-defaults.txt"
 
     // Alignment
-    aligner                    = 'star_salmon'
+    aligner                    = 'hisat2'
     use_sentieon_star          = false
     pseudo_aligner             = null
     pseudo_aligner_kmer_size   = 31


### PR DESCRIPTION
## Summary
This pull request swaps out the STAR aligner for HISAT2 in the RNA-seq pipeline as requested.

## Changes Made
- Modified `nextflow.config` to change the default `aligner` parameter from `'star_salmon'` to `'hisat2'`

## Key Considerations
⚠️ **Important**: When using HISAT2 as the aligner, please note that:
- HISAT2 mode focuses on **alignment and QC analysis**
- **Quantification is not performed by default** (unlike STAR+Salmon mode)
- This is because there isn't an appropriate option to calculate accurate expression estimates from HISAT2-derived genomic alignments
- This route is suitable if you prefer HISAT2 for alignment, QC, and other downstream analyses compatible with HISAT2 output

## Pipeline Behavior
With HISAT2 selected, the pipeline will:
✅ Perform quality control on input reads
✅ Align reads to the reference genome using HISAT2
✅ Generate BAM files and alignment statistics
✅ Perform various QC analyses (MultiQC, RSeQC, etc.)
❌ Not perform transcript quantification

## Usage
After merging, the pipeline will use HISAT2 by default. To explicitly specify the aligner, you can still use:
```bash
nextflow run main.nf --aligner hisat2 [other parameters]
```

## Testing
The pipeline structure already includes full HISAT2 support through the `FASTQ_ALIGN_HISAT2` subworkflow, so no additional modules were needed.